### PR TITLE
adjusted border and fixed repo url

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -60,6 +60,7 @@
 
 .md-main__inner{
     min-width:90%;
+    margin-top:0em;
 }
 
 
@@ -67,6 +68,19 @@
 .md-content{
     border-left: 1px solid rgb(75, 73, 73); /* sets a 1px solid black border on the left side of the element */
     border-right: 1px solid rgb(75, 73, 73); /* sets a 1px solid black border on the right side of the element */
+    border-bottom: 1px solid rgb(75, 73, 73);
+}
+
+[data-md-color-scheme="slate"] .md-content{
+    border-color: white /* sets a 1px solid black border on the left side of the element */
+}
+
+h1{
+    color: rgb(35, 25, 228);
+}
+
+[data-md-color-scheme="slate"] h1{
+    color:white;
 }
 
 .md-typeset hr {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Fortify DevOps Guide
 base_url: /fortify-dev-guide
-repo_url: https://https://github.com/devsec-guides/fortify_dev_guide
+repo_url: https://github.com/devsec-guides/fortify_dev_guide
 extra_css:
   - stylesheets/extra.css
 theme:


### PR DESCRIPTION
The border for the main content has a better look, it goes all the way up to the header and has a bottom border now.

The repo URL had a bad syntax, this has been adjusted.