### PR TITLE
adjust iframes for slides with a css property

### DIFF
--- a/docs/slides/demo.md
+++ b/docs/slides/demo.md
@@ -1,4 +1,4 @@
 
 <div style="text-align:center">
-<iframe src="../demo_slide.html"/>
+<iframe src="../demo_slide.html" class="slide-deck"/>
 </div>

--- a/docs/slides/template.md
+++ b/docs/slides/template.md
@@ -1,3 +1,3 @@
 <div style="text-align:center">
-<iframe src="../template_slide.html"/>
+<iframe src="../template_slide.html" class="slide-deck"/>
 </div>

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -89,7 +89,7 @@ h1{
     margin: 1.5em 0;
 }
 
-iframe{
+.slide-deck{
     width:100%; 
     height:900px
 }


### PR DESCRIPTION
The iframes that contain reveal.js slides now have a css property that can be targeted for styling
Example

The iframe that specifies the source of an html file that will hold the actual slide.

`<iframe src="../template_slide.html" class="slide-deck"/>`

css styling in the extra.css file

```
.slide-deck{
    width:100%; 
    height:900px
}
```