### PR TITLE
fix broken mkdocs gh-deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.x
+          python-version: '3.11'
       - uses: actions/cache@v2
         with:
           key: ${{ github.ref }}


### PR DESCRIPTION
Python version 3.12 breaks mkdocs gh-deploy.

Specifying in the github action that the python version should be 3.11