### PR TITLE
use variables to build and deploy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,13 @@ on:
   pull_request:
     branches:
       main
+env:
+  REPO_NAME: ${{ vars.REPO_NAME }}
+  REPO_URL: ${{ vars.REPO_URL}}
+
+  SITE_NAME: ${{ vars.SITE_NAME }}
+  SITE_URL: ${{ vars.SITE_URL }}
+
 permissions:
   contents: write
 jobs:
@@ -18,4 +25,8 @@ jobs:
         with:
           key: ${{ github.ref }}
           path: .cache
-      - run: pip install -r requirements.txt
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: MKDocs Build
+        run: mkdocs build --clean

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,18 +1,26 @@
 name: deploy
 
-env:
-  DOC_VERSION: "0.1.4"
-
 on:
   workflow_dispatch:
   push:
-    branches: 
+    branches:
       - main
+
+env:
+  DOC_VERSION: "0.1.4"
+  REPO_NAME: ${{ vars.REPO_NAME }}
+  REPO_URL: ${{ vars.REPO_URL}}
+
+  SITE_NAME: ${{ vars.SITE_NAME }}
+  SITE_URL: ${{ vars.SITE_URL }}
+
 permissions:
   contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -22,10 +30,20 @@ jobs:
         with:
           key: ${{ github.ref }}
           path: .cache
-      - run: pip install -r requirements.txt
-      - run: |
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Configure Git
+        run: |
           git config user.name mkdocs-bot
           git config user.email mkdocs-bot@example.com
-          git fetch origin gh-pages --depth=1
-          mike set-default latest
-          mike deploy ${{ env.DOC_VERSION }} latest --push -u
+
+      - name: Deploy to Github pages
+        run: |
+          if [ -n "${{ env.DOC_VERSION }}" ]; then
+            mike set-default latest
+            mike deploy ${{ env.DOC_VERSION }} latest --push -u
+          else
+            mkdocs gh-deploy --force
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ ENV/
 site*/
 
 .vscode/*
+
+# local environment file
+env.yml

--- a/env.yml.example
+++ b/env.yml.example
@@ -1,0 +1,5 @@
+SITE_NAME: 
+SITE_URL: 
+
+REPO_NAME: 
+REPO_URL: 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,9 +1,9 @@
-site_name: Fortify DevOps Guide
-site_url: https://treisland.github.io/fortify_docs/
-site_author: Tre Island
+site_name: !ENV SITE_NAME
+site_url: !ENV SITE_URL
 
-repo_name: treisland/fortify_docs
-repo_url: https://github.com/treisland/fortify_docs
+repo_name: !ENV REPO_NAME
+repo_url: !ENV REPO_URL
+
 edit_uri: edit/main/docs/
 
 extra_css:

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1,0 +1,27 @@
+import os
+import yaml
+
+# Specify the path to your YAML configuration file
+CONFIG_FILE=os.path.join(os.getcwd(), 'env.yml')
+
+try:
+# Read the YAML configuration
+    with open(CONFIG_FILE, "r") as yaml_file:
+        config_data = yaml.safe_load(yaml_file)
+
+    current_key=""
+    # Set environment variables based on the configuration data
+    for key, value in config_data.items():
+        current_key=key
+
+        os.environ[key] = str(value)
+except FileNotFoundError:
+    print("The configuration file was not found. Please make sure config.yml file exists in the root directory")
+    exit(1)
+except KeyError:
+    print(f"The configuration file is missing {current_key}")
+    exit(1)
+
+# Run the mkdocs serve command
+os.system('mkdocs build --clean')
+

--- a/scripts/gh-deploy.py
+++ b/scripts/gh-deploy.py
@@ -1,0 +1,27 @@
+import os
+import yaml
+
+# Specify the path to your YAML configuration file
+CONFIG_FILE=os.path.join(os.getcwd(), 'env.yml')
+
+try:
+# Read the YAML configuration
+    with open(CONFIG_FILE, "r") as yaml_file:
+        config_data = yaml.safe_load(yaml_file)
+
+    current_key=""
+    # Set environment variables based on the configuration data
+    for key, value in config_data.items():
+        current_key=key
+
+        os.environ[key] = str(value)
+except FileNotFoundError:
+    print("The configuration file was not found. Please make sure config.yml file exists in the root directory")
+    exit(1)
+except KeyError:
+    print(f"The configuration file is missing {current_key}")
+    exit(1)
+
+# Run the mkdocs serve command
+os.system('mkdocs gh-deploy')
+

--- a/scripts/serve.py
+++ b/scripts/serve.py
@@ -1,0 +1,27 @@
+import os
+import yaml
+
+# Specify the path to your YAML configuration file
+CONFIG_FILE=os.path.join(os.getcwd(), 'env.yml')
+
+try:
+# Read the YAML configuration
+    with open(CONFIG_FILE, "r") as yaml_file:
+        config_data = yaml.safe_load(yaml_file)
+
+    current_key=""
+    # Set environment variables based on the configuration data
+    for key, value in config_data.items():
+        current_key=key
+
+        os.environ[key] = str(value)
+except FileNotFoundError:
+    print("The configuration file was not found. Please make sure config.yml file exists in the root directory")
+    exit(1)
+except KeyError:
+    print(f"The configuration file is missing {current_key}")
+    exit(1)
+
+# Run the mkdocs serve command
+os.system('mkdocs serve')
+


### PR DESCRIPTION
mkdocs.yaml file can now read variables for the following values.
- site_url, site_name, repo_url, repo_name

Added scripts directory and the ability to read these values locally from a file called env.yml (end user must create this file by cloning env.yml.example)

Will need to update the README.md in the future for updated instructions.